### PR TITLE
WIP on modinfo/PE parsing, misc. minor stuff

### DIFF
--- a/src/bridge/bridgemain.cpp
+++ b/src/bridge/bridgemain.cpp
@@ -1075,9 +1075,9 @@ BRIDGE_IMPEXP void DbgMenuPrepare(int hMenu)
     _dbg_sendmessage(DBG_MENU_PREPARE, (void*)hMenu, nullptr);
 }
 
-BRIDGE_IMPEXP void DbgGetSymbolInfo(void* symbol, SYMBOLINFO* info)
+BRIDGE_IMPEXP void DbgGetSymbolInfo(const SYMBOLPTR* symbolptr, SYMBOLINFO* info)
 {
-    _dbg_sendmessage(DBG_GET_SYMBOL_INFO, symbol, info);
+    _dbg_sendmessage(DBG_GET_SYMBOL_INFO, (void*)symbolptr, info);
 }
 
 BRIDGE_IMPEXP const char* GuiTranslateText(const char* Source)
@@ -1695,9 +1695,9 @@ BRIDGE_IMPEXP void GuiOpenTraceFile(const char* fileName)
     _gui_sendmessage(GUI_OPEN_TRACE_FILE, (void*)fileName, nullptr);
 }
 
-BRIDGE_IMPEXP void GuiSetModuleSymbols(duint base, ListOf(void*) symbols)
+BRIDGE_IMPEXP void GuiInvalidateSymbolSource(duint base)
 {
-    _gui_sendmessage(GUI_SET_MODULE_SYMBOLS, (void*)base, symbols);
+    _gui_sendmessage(GUI_INVALIDATE_SYMBOL_SOURCE, (void*)base, nullptr);
 }
 
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)

--- a/src/bridge/bridgemain.h
+++ b/src/bridge/bridgemain.h
@@ -495,12 +495,19 @@ typedef enum
     hw_qword
 } BPHWSIZE;
 
+typedef enum
+{
+    sym_import,
+    sym_export,
+    sym_symbol
+} SYMBOLTYPE;
+
 //Debugger typedefs
 typedef MEMORY_SIZE VALUE_SIZE;
-typedef struct SYMBOLINFO_ SYMBOLINFO;
+
 typedef struct DBGFUNCTIONS_ DBGFUNCTIONS;
 
-typedef void (*CBSYMBOLENUM)(SYMBOLINFO* symbol, void* user);
+typedef bool (*CBSYMBOLENUM)(const struct SYMBOLPTR_* symbol, void* user);
 
 //Debugger structs
 typedef struct
@@ -583,13 +590,15 @@ typedef struct
     FUNCTION args;
 } BRIDGE_ADDRINFO;
 
-struct SYMBOLINFO_
+typedef struct SYMBOLINFO_
 {
     duint addr;
     char* decoratedSymbol;
     char* undecoratedSymbol;
-    bool isImported;
-};
+    SYMBOLTYPE type;
+    bool freeDecorated;
+    bool freeUndecorated;
+} SYMBOLINFO;
 
 typedef struct
 {
@@ -889,6 +898,12 @@ typedef struct
     XREF_RECORD* references;
 } XREF_INFO;
 
+typedef struct SYMBOLPTR_
+{
+    duint modbase;
+    const void* symbol;
+} SYMBOLPTR;
+
 //Debugger functions
 BRIDGE_IMPEXP const char* DbgInit();
 BRIDGE_IMPEXP void DbgExit();
@@ -1013,7 +1028,7 @@ BRIDGE_IMPEXP duint DbgGetTebAddress(DWORD ThreadId);
 BRIDGE_IMPEXP bool DbgAnalyzeFunction(duint entry, BridgeCFGraphList* graph);
 BRIDGE_IMPEXP duint DbgEval(const char* expression, bool* success = 0);
 BRIDGE_IMPEXP void DbgMenuPrepare(int hMenu);
-BRIDGE_IMPEXP void DbgGetSymbolInfo(void* symbol, SYMBOLINFO* info);
+BRIDGE_IMPEXP void DbgGetSymbolInfo(const SYMBOLPTR* symbolptr, SYMBOLINFO* info);
 
 //Gui defines
 #define GUI_PLUGIN_MENU 0
@@ -1142,7 +1157,7 @@ typedef enum
     GUI_REF_ADDCOMMAND,             // param1=const char* title,    param2=const char* command
     GUI_OPEN_TRACE_FILE,            // param1=const char* file name,param2=unused
     GUI_UPDATE_TRACE_BROWSER,       // param1=unused,               param2=unused
-    GUI_SET_MODULE_SYMBOLS,         // param1=duint base,           param2=ListOf(void*) symbols
+    GUI_INVALIDATE_SYMBOL_SOURCE,   // param1=duint base,           param2=unused
 } GUIMSG;
 
 //GUI Typedefs
@@ -1319,7 +1334,7 @@ BRIDGE_IMPEXP void GuiFlushLog();
 BRIDGE_IMPEXP void GuiReferenceAddCommand(const char* title, const char* command);
 BRIDGE_IMPEXP void GuiUpdateTraceBrowser();
 BRIDGE_IMPEXP void GuiOpenTraceFile(const char* fileName);
-BRIDGE_IMPEXP void GuiSetModuleSymbols(duint base, ListOf(void*) symbols);
+BRIDGE_IMPEXP void GuiInvalidateSymbolSource(duint base);
 
 #ifdef __cplusplus
 }

--- a/src/dbg/dbghelp_safe.h
+++ b/src/dbg/dbghelp_safe.h
@@ -10,13 +10,13 @@
 void SafeDbghelpInitialize();
 void SafeDbghelpDeinitialize();
 
-DWORD
+/*DWORD
 SafeUnDecorateSymbolName(
     __in PCSTR name,
     __out_ecount(maxStringLength) PSTR outputString,
     __in DWORD maxStringLength,
     __in DWORD flags
-);
+);*/
 BOOL
 SafeSymUnloadModule64(
     __in HANDLE hProcess,

--- a/src/dbg/module.cpp
+++ b/src/dbg/module.cpp
@@ -381,6 +381,17 @@ void ReadDebugDirectory(MODINFO & Info, ULONG_PTR FileMapVA)
             return "IMAGE_DEBUG_TYPE_RESERVED10";
         case IMAGE_DEBUG_TYPE_CLSID:
             return "IMAGE_DEBUG_TYPE_CLSID";
+        // The following types aren't defined in older Windows SDKs, so just count up from here so we can still return the names for them
+        case (IMAGE_DEBUG_TYPE_CLSID + 1):
+            return "IMAGE_DEBUG_TYPE_VC_FEATURE";
+        case (IMAGE_DEBUG_TYPE_CLSID + 2):
+            return "IMAGE_DEBUG_TYPE_POGO"; // For anyone grepping this: /NOCOFFGRPINFO is the undocumented linker switch to get rid of this crap. You're welcome
+        case (IMAGE_DEBUG_TYPE_CLSID + 3):
+            return "IMAGE_DEBUG_TYPE_ILTCG";
+        case (IMAGE_DEBUG_TYPE_CLSID + 4):
+            return "IMAGE_DEBUG_TYPE_MPX";
+        case (IMAGE_DEBUG_TYPE_CLSID + 5):
+            return "IMAGE_DEBUG_TYPE_REPRO";
         default:
             return "unknown";
         }

--- a/src/dbg/module.cpp
+++ b/src/dbg/module.cpp
@@ -107,6 +107,11 @@ static void ReadExportDirectory(MODINFO & Info, ULONG_PTR FileMapVA)
     Info.exports.reserve(exportDir->NumberOfFunctions);
     Info.exportOrdinalBase = exportDir->Base;
 
+    // TODO: 'invalid address' below means an RVA that is obviously invalid, like being greater than SizeOfImage.
+    // In that case rva2offset will return a VA of 0 and we can ignore it. However the ntdll loader (and this code)
+    // will still crash on corrupt or malicious inputs that are seemingly valid. Find out how common this is
+    // (i.e. does it warrant wrapping everything in try/except?) and whether there are better solutions.
+    // Note that we're loading this file because the debuggee did; that makes it at least somewhat plausible that we will also survive
     for(DWORD i = 0; i < exportDir->NumberOfFunctions; i++)
     {
         Info.exports.emplace_back();

--- a/src/dbg/module.cpp
+++ b/src/dbg/module.cpp
@@ -62,14 +62,13 @@ static NTSTATUS ImageNtHeaders(duint base, duint size, PIMAGE_NT_HEADERS* outHea
 static ULONG64 RvaToVa(ULONG64 base, PIMAGE_NT_HEADERS ntHeaders, ULONG64 rva)
 {
     PIMAGE_SECTION_HEADER section = IMAGE_FIRST_SECTION(ntHeaders);
-    const WORD numSections = ntHeaders->FileHeader.NumberOfSections;
-    for(WORD i = 0; i < numSections; ++i)
+    for(WORD i = 0; i < ntHeaders->FileHeader.NumberOfSections; ++i)
     {
-        if(section->VirtualAddress <= rva &&
-                section->VirtualAddress + section->Misc.VirtualSize > rva)
+        if(rva >= section->VirtualAddress &&
+                rva < section->VirtualAddress + section->SizeOfRawData)
         {
             ASSERT_TRUE(rva != 0); // Following garbage in is garbage out, RVA 0 should always yield VA 0
-            return base + (rva - section->VirtualAddress + section->PointerToRawData);
+            return base + (rva - section->VirtualAddress) + section->PointerToRawData;
         }
         section++;
     }

--- a/src/dbg/module.h
+++ b/src/dbg/module.h
@@ -37,21 +37,25 @@ struct PdbValidationData
     }
 };
 
-struct MODEXPORT
+struct MODEXPORT : SymbolInfoGui
 {
     DWORD ordinal = 0;
     DWORD rva = 0;
     bool forwarded = false;
     String forwardName;
     String name;
+
+    virtual void convertToGuiSymbol(duint base, SYMBOLINFO* info) const override;
 };
 
-struct MODIMPORT
+struct MODIMPORT : SymbolInfoGui
 {
     size_t moduleIndex; //index in MODINFO.importModules
     DWORD iatRva;
     duint ordinal; //equal to -1 if imported by name
     String name;
+
+    virtual void convertToGuiSymbol(duint base, SYMBOLINFO* info) const override;
 };
 
 struct MODINFO
@@ -98,8 +102,15 @@ struct MODINFO
         memset(path, 0, sizeof(path));
     }
 
+    ~MODINFO()
+    {
+        unmapFile();
+        unloadSymbols();
+    }
+
     bool loadSymbols();
     void unloadSymbols();
+    void unmapFile();
 };
 
 bool ModLoad(duint Base, duint Size, const char* FullPath);

--- a/src/dbg/pdbdiafile.cpp
+++ b/src/dbg/pdbdiafile.cpp
@@ -115,11 +115,7 @@ public:
         if(hFile == INVALID_HANDLE_VALUE)
             return HRESULT_FROM_WIN32(GetLastError());
 
-        DiaFileStream* out = new DiaFileStream(hFile);
-        *ppStream = out;
-
-        if(*ppStream == NULL)
-            CloseHandle(hFile);
+        *ppStream = new DiaFileStream(hFile);
 
         return S_OK;
     }
@@ -391,25 +387,21 @@ bool PDBDiaFile::open(const wchar_t* file, uint64_t loadAddress, DiaValidationDa
 
 bool PDBDiaFile::isOpen() const
 {
-    return m_session != nullptr && m_dataSource != nullptr;
+    return m_session != nullptr || m_dataSource != nullptr;
 }
 
 bool PDBDiaFile::close()
 {
-    if(m_dataSource == nullptr)
-        return false;
-    if(m_session == nullptr)
-        return false;
-
-    m_session->Release();
-    m_dataSource->Release();
-    m_session = nullptr;
-    m_dataSource = nullptr;
-
-    if(m_stream != nullptr)
+    if(m_session)
     {
-        delete(DiaFileStream*)m_stream;
-        m_stream = nullptr;
+        m_session->Release();
+        m_session = nullptr;
+    }
+
+    if(m_dataSource)
+    {
+        m_dataSource->Release();
+        m_dataSource = nullptr;
     }
 
     return true;

--- a/src/dbg/symbolsourcebase.h
+++ b/src/dbg/symbolsourcebase.h
@@ -7,19 +7,33 @@
 #include <vector>
 #include <functional>
 
-struct SymbolInfo
+struct SymbolInfoGui
 {
-    duint va;
+    virtual void convertToGuiSymbol(duint base, SYMBOLINFO* info) const = 0;
+};
+
+struct SymbolInfo : SymbolInfoGui
+{
+    duint rva;
     duint size;
     int32 disp;
     String decoratedName;
     String undecoratedName;
     bool publicSymbol;
+
+    void convertToGuiSymbol(duint modbase, SYMBOLINFO* info) const override
+    {
+        info->addr = modbase + this->rva;
+        info->decoratedSymbol = (char*)this->decoratedName.c_str();
+        info->undecoratedSymbol = (char*)this->undecoratedName.c_str();
+        info->type = sym_symbol;
+        info->freeDecorated = info->freeUndecorated = false;
+    }
 };
 
 struct LineInfo
 {
-    duint addr;
+    duint rva;
     duint size;
     duint disp;
     int lineNumber;
@@ -89,6 +103,7 @@ public:
         return false; // Stub
     }
 
+    // only call if isOpen && !isLoading
     virtual void enumSymbols(const CbEnumSymbol & cbEnum)
     {
         // Stub

--- a/src/dbg/symbolsourcedia.cpp
+++ b/src/dbg/symbolsourcedia.cpp
@@ -14,6 +14,8 @@ SymbolSourceDIA::SymbolSourceDIA()
 SymbolSourceDIA::~SymbolSourceDIA()
 {
     cancelLoading();
+    if(_imageBase)
+        GuiInvalidateSymbolSource(_imageBase);
 }
 
 static void SetThreadDescription(HANDLE hThread, WString name)
@@ -38,6 +40,7 @@ bool SymbolSourceDIA::loadPDB(const std::string & path, duint imageBase, duint i
         _imageSize = imageSize;
         _imageBase = imageBase;
         _requiresShutdown = false;
+        _symbolsLoaded = false;
         _loadCounter.store(2);
         _symbolsThread = CreateThread(nullptr, 0, [](LPVOID thisPtr) -> DWORD
         {
@@ -75,17 +78,25 @@ bool SymbolSourceDIA::cancelLoading()
     {
         WaitForSingleObject(_symbolsThread, INFINITE);
         CloseHandle(_symbolsThread);
+        _symbolsThread = nullptr;
     }
     if(_sourceLinesThread)
     {
         WaitForSingleObject(_sourceLinesThread, INFINITE);
         CloseHandle(_sourceLinesThread);
+        _sourceLinesThread = nullptr;
     }
     return true;
 }
 
 void SymbolSourceDIA::loadPDBAsync()
 {
+}
+
+template<size_t Count>
+static bool startsWith(const char* str, const char(&prefix)[Count])
+{
+    return strncmp(str, prefix, Count - 1) == 0;
 }
 
 bool SymbolSourceDIA::loadSymbolsAsync()
@@ -110,6 +121,15 @@ bool SymbolSourceDIA::loadSymbolsAsync()
         if(_requiresShutdown)
             return false;
 
+        if(sym.name.c_str()[0] == 0x7F)
+            return true;
+
+#define filter(prefix) if(startsWith(sym.name.c_str(), prefix)) return true
+        filter("__imp__");
+        filter("__NULL_IMPORT_DESCRIPTOR");
+        filter("__IMPORT_DESCRIPTOR_");
+#undef filter
+
         if(sym.type == DiaSymbolType::PUBLIC ||
         sym.type == DiaSymbolType::FUNCTION ||
         sym.type == DiaSymbolType::LABEL ||
@@ -120,7 +140,7 @@ bool SymbolSourceDIA::loadSymbolsAsync()
             symInfo.undecoratedName = sym.undecoratedName;
             symInfo.size = sym.size;
             symInfo.disp = sym.disp;
-            symInfo.va = _imageBase + sym.virtualAddress;
+            symInfo.rva = sym.virtualAddress;
             symInfo.publicSymbol = sym.publicSymbol;
 
             // Check if we already have it inside, private symbols have priority over public symbols.
@@ -188,6 +208,7 @@ bool SymbolSourceDIA::loadSymbolsAsync()
             _symNameMap[i] = nameIndex;
         }
         std::sort(_symNameMap.begin(), _symNameMap.end());
+        _symbolsLoaded = true;
     }
 
     DWORD ms = GetTickCount() - loadStart;
@@ -195,17 +216,7 @@ bool SymbolSourceDIA::loadSymbolsAsync()
 
     GuiSymbolLogAdd(StringUtils::sprintf("[%p] Loaded %d symbols in %.03fs\n", _imageBase, _symAddrs.size(), secs).c_str());
 
-    //TODO: make beautiful
-    ListInfo blub;
-    blub.count = _symAddrs.size();
-    blub.size = blub.count * sizeof(void*);
-    std::vector<SymbolInfo*> fuck;
-    fuck.resize(_symAddrs.size());
-    size_t i = 0;
-    for(auto it = _symAddrs.begin(); it != _symAddrs.end(); ++it)
-        fuck[i++] = &_symData[it->second];
-    blub.data = fuck.data();
-    GuiSetModuleSymbols(_imageBase, &blub);
+    GuiInvalidateSymbolSource(_imageBase);
 
     GuiUpdateAllViews();
 
@@ -340,7 +351,7 @@ bool SymbolSourceDIA::findSymbolExactOrLower(duint rva, SymbolInfo & symInfo)
     if(it != _symAddrs.end())
     {
         symInfo = _symData[it->second];
-        symInfo.disp = (int32_t)(rva - (symInfo.va - _imageBase));
+        symInfo.disp = (int32_t)(rva - symInfo.rva);
         return true;
     }
 
@@ -350,6 +361,8 @@ bool SymbolSourceDIA::findSymbolExactOrLower(duint rva, SymbolInfo & symInfo)
 void SymbolSourceDIA::enumSymbols(const CbEnumSymbol & cbEnum)
 {
     ScopedSpinLock lock(_lockSymbols);
+    if(!_symbolsLoaded)
+        return;
 
     for(auto & it : _symAddrs)
     {
@@ -394,6 +407,8 @@ ForwardIt binary_find(ForwardIt first, ForwardIt last, const T & value, Compare 
 bool SymbolSourceDIA::findSymbolByName(const std::string & name, SymbolInfo & symInfo, bool caseSensitive)
 {
     ScopedSpinLock lock(_lockSymbols);
+    if(!_symbolsLoaded)
+        return false;
 
     NameIndex find;
     find.name = name.c_str();
@@ -435,6 +450,8 @@ bool SymbolSourceDIA::findSymbolsByPrefix(const std::string & prefix, const std:
     } prefixCmp(prefix.size());
 
     ScopedSpinLock lock(_lockSymbols);
+    if(!_symbolsLoaded)
+        return false;
 
     NameIndex find;
     find.name = prefix.c_str();

--- a/src/dbg/symbolsourcedia.cpp
+++ b/src/dbg/symbolsourcedia.cpp
@@ -3,30 +3,46 @@
 #include "debugger.h"
 #include <algorithm>
 
+typedef BOOL(NTAPI* fnRtlQueryPerformanceFrequency)(PLARGE_INTEGER frequency);
+typedef BOOL(NTAPI* fnRtlQueryPerformanceCounter)(PLARGE_INTEGER performanceCount);
+
 SymbolSourceDIA::SymbolSourceDIA()
-    : _requiresShutdown(false),
-      _imageBase(0),
+    : _isOpen(false),
+      _requiresShutdown(false),
       _loadCounter(0),
-      _isOpen(false)
+      _imageBase(0),
+      _imageSize(0)
 {
 }
 
 SymbolSourceDIA::~SymbolSourceDIA()
 {
-    cancelLoading();
+    SymbolSourceDIA::cancelLoading();
     if(_imageBase)
         GuiInvalidateSymbolSource(_imageBase);
 }
 
-static void SetThreadDescription(HANDLE hThread, WString name)
+static void SetWin10ThreadDescription(HANDLE threadHandle, const WString & name)
 {
     typedef HRESULT(WINAPI * fnSetThreadDescription)(HANDLE hThread, PCWSTR lpThreadDescription);
 
-    fnSetThreadDescription fp = (fnSetThreadDescription)GetProcAddress(GetModuleHandleA("kernel32.dll"), "SetThreadDescription");
+    fnSetThreadDescription fp = (fnSetThreadDescription)GetProcAddress(GetModuleHandleW(L"kernel32.dll"), "SetThreadDescription");
     if(!fp)
         return; // Only available on windows 10.
 
-    fp(hThread, name.c_str());
+    fp(threadHandle, name.c_str());
+}
+
+DWORD WINAPI SymbolSourceDIA::SymbolsThread(void* parameter)
+{
+    ((SymbolSourceDIA*)parameter)->loadSymbolsAsync();
+    return 0;
+}
+
+DWORD WINAPI SymbolSourceDIA::SourceLinesThread(void* parameter)
+{
+    ((SymbolSourceDIA*)parameter)->loadSourceLinesAsync();
+    return 0;
 }
 
 bool SymbolSourceDIA::loadPDB(const std::string & path, duint imageBase, duint imageSize, DiaValidationData_t* validationData)
@@ -42,18 +58,10 @@ bool SymbolSourceDIA::loadPDB(const std::string & path, duint imageBase, duint i
         _requiresShutdown = false;
         _symbolsLoaded = false;
         _loadCounter.store(2);
-        _symbolsThread = CreateThread(nullptr, 0, [](LPVOID thisPtr) -> DWORD
-        {
-            ((SymbolSourceDIA*)thisPtr)->loadSymbolsAsync();
-            return 0;
-        }, this, CREATE_SUSPENDED, nullptr);
-        SetThreadDescription(_symbolsThread, L"SymbolsThread");
-        _sourceLinesThread = CreateThread(nullptr, 0, [](LPVOID thisPtr) -> DWORD
-        {
-            ((SymbolSourceDIA*)thisPtr)->loadSourceLinesAsync();
-            return 0;
-        }, this, CREATE_SUSPENDED, nullptr);
-        SetThreadDescription(_sourceLinesThread, L"SourceLinesThread");
+        _symbolsThread = CreateThread(nullptr, 0, SymbolsThread, this, CREATE_SUSPENDED, nullptr);
+        SetWin10ThreadDescription(_symbolsThread, L"SymbolsThread");
+        _sourceLinesThread = CreateThread(nullptr, 0, SourceLinesThread, this, CREATE_SUSPENDED, nullptr);
+        SetWin10ThreadDescription(_sourceLinesThread, L"SourceLinesThread");
         ResumeThread(_symbolsThread);
         ResumeThread(_sourceLinesThread);
     }
@@ -110,8 +118,16 @@ bool SymbolSourceDIA::loadSymbolsAsync()
         return false;
     }
 
+    const auto fpRtlQueryPerformanceFrequency = (fnRtlQueryPerformanceFrequency)GetProcAddress(GetModuleHandleW(L"ntdll.dll"), "RtlQueryPerformanceFrequency");
+    const auto fpRtlQueryPerformanceCounter = (fnRtlQueryPerformanceCounter)GetProcAddress(GetModuleHandleW(L"ntdll.dll"), "RtlQueryPerformanceCounter");
+
     DWORD lastUpdate = 0;
-    DWORD loadStart = GetTickCount();
+    LARGE_INTEGER frequency, loadStart, loadEnd, microSecs;
+    if(fpRtlQueryPerformanceFrequency != nullptr && fpRtlQueryPerformanceCounter != nullptr)
+    {
+        fpRtlQueryPerformanceFrequency(&frequency);
+        fpRtlQueryPerformanceCounter(&loadStart);
+    }
 
     PDBDiaFile::Query_t query;
     query.collectSize = true;
@@ -211,10 +227,14 @@ bool SymbolSourceDIA::loadSymbolsAsync()
         _symbolsLoaded = true;
     }
 
-    DWORD ms = GetTickCount() - loadStart;
-    double secs = (double)ms / 1000.0;
+    if(fpRtlQueryPerformanceFrequency != nullptr && fpRtlQueryPerformanceCounter != nullptr)
+    {
+        fpRtlQueryPerformanceCounter(&loadEnd);
+        microSecs.QuadPart = ((loadEnd.QuadPart - loadStart.QuadPart) * 1000000LL) / frequency.QuadPart;
+        double secs = (double)microSecs.QuadPart / 1000000.0;
 
-    GuiSymbolLogAdd(StringUtils::sprintf("[%p] Loaded %d symbols in %.03fs\n", _imageBase, _symAddrs.size(), secs).c_str());
+        GuiSymbolLogAdd(StringUtils::sprintf("[%p] Loaded %d symbols in %.03fs\n", _imageBase, _symAddrs.size(), secs).c_str());
+    }
 
     GuiInvalidateSymbolSource(_imageBase);
 
@@ -234,7 +254,15 @@ bool SymbolSourceDIA::loadSourceLinesAsync()
         return false;
     }
 
-    DWORD lineLoadStart = GetTickCount();
+    const auto fpRtlQueryPerformanceFrequency = (fnRtlQueryPerformanceFrequency)GetProcAddress(GetModuleHandleW(L"ntdll.dll"), "RtlQueryPerformanceFrequency");
+    const auto fpRtlQueryPerformanceCounter = (fnRtlQueryPerformanceCounter)GetProcAddress(GetModuleHandleW(L"ntdll.dll"), "RtlQueryPerformanceCounter");
+
+    LARGE_INTEGER frequency, lineLoadStart, lineLoadEnd, microSecs;
+    if(fpRtlQueryPerformanceFrequency != nullptr && fpRtlQueryPerformanceCounter != nullptr)
+    {
+        fpRtlQueryPerformanceFrequency(&frequency);
+        fpRtlQueryPerformanceCounter(&lineLoadStart);
+    }
 
     const size_t rangeSize = 1024 * 1024;
 
@@ -295,10 +323,14 @@ bool SymbolSourceDIA::loadSourceLinesAsync()
     if(_requiresShutdown)
         return false;
 
-    DWORD ms = GetTickCount() - lineLoadStart;
-    double secs = (double)ms / 1000.0;
+    if(fpRtlQueryPerformanceFrequency != nullptr && fpRtlQueryPerformanceCounter != nullptr)
+    {
+        fpRtlQueryPerformanceCounter(&lineLoadEnd);
+        microSecs.QuadPart = ((lineLoadEnd.QuadPart - lineLoadStart.QuadPart) * 1000000LL) / frequency.QuadPart;
+        double secs = (double)microSecs.QuadPart / 1000000.0;
 
-    GuiSymbolLogAdd(StringUtils::sprintf("[%p] Loaded %d line infos in %.03fs\n", _imageBase, _lines.size(), secs).c_str());
+        GuiSymbolLogAdd(StringUtils::sprintf("[%p] Loaded %d line infos in %.03fs\n", _imageBase, _lines.size(), secs).c_str());
+    }
 
     GuiUpdateAllViews();
 

--- a/src/dbg/symbolsourcedia.h
+++ b/src/dbg/symbolsourcedia.h
@@ -1,6 +1,8 @@
 #ifndef _SYMBOLSOURCEDIA_H_
 #define _SYMBOLSOURCEDIA_H_
 
+#include "_global.h"
+
 #include "pdbdiafile.h"
 #include "symbolsourcebase.h"
 #include "sortedlru.h"

--- a/src/dbg/symbolsourcedia.h
+++ b/src/dbg/symbolsourcedia.h
@@ -100,6 +100,7 @@ private:
     duint _imageBase;
     duint _imageSize;
     SpinLock _lockSymbols;
+    bool _symbolsLoaded = false;
     SpinLock _lockLines;
 
 private:

--- a/src/dbg/symbolsourcedia.h
+++ b/src/dbg/symbolsourcedia.h
@@ -155,6 +155,9 @@ private:
     void loadPDBAsync();
     bool loadSymbolsAsync();
     bool loadSourceLinesAsync();
+
+    static DWORD WINAPI SymbolsThread(void* parameter);
+    static DWORD WINAPI SourceLinesThread(void* parameter);
 };
 
 #endif // _SYMBOLSOURCEPDB_H_

--- a/src/dbg/symcache.cpp
+++ b/src/dbg/symcache.cpp
@@ -39,7 +39,7 @@ bool SymbolFromAddressExact(duint address, SymbolInfo & symInfo)
             if(found != modInfo->exportsByRva.end())
             {
                 auto & modExport = modInfo->exports.at(*found);
-                symInfo.va = modExport.rva + modInfo->base;
+                symInfo.rva = modExport.rva;
                 symInfo.size = 0;
                 symInfo.disp = 0;
                 symInfo.decoratedName = modExport.name;

--- a/src/gui/Src/BasicView/AbstractStdTable.h
+++ b/src/gui/Src/BasicView/AbstractStdTable.h
@@ -69,12 +69,14 @@ public slots:
 protected:
     QString copyTable(const std::vector<int> & colWidths);
 
-    struct
+    struct SelectionData_t
     {
         int firstSelectedIndex = 0;
         int fromIndex = 0;
         int toIndex = 0;
-    } mSelection;
+    };
+
+    SelectionData_t mSelection;
 
     enum
     {

--- a/src/gui/Src/Bridge/Bridge.cpp
+++ b/src/gui/Src/Bridge/Bridge.cpp
@@ -840,10 +840,8 @@ void* Bridge::processMessage(GUIMSG type, void* param1, void* param2)
         emit updateTraceBrowser();
         break;
 
-    case GUI_SET_MODULE_SYMBOLS:
-        std::vector<void*> moduleSymbols;
-        BridgeList<void*>::ToVector((const ListInfo*)param2, moduleSymbols, false);
-        symbolView->setModuleSymbols(duint(param1), moduleSymbols);
+    case GUI_INVALIDATE_SYMBOL_SOURCE:
+        symbolView->invalidateSymbolSource(duint(param1));
         break;
     }
 

--- a/src/gui/Src/Gui/SymbolView.cpp
+++ b/src/gui/Src/Gui/SymbolView.cpp
@@ -145,11 +145,21 @@ void SymbolView::loadWindowSettings()
     loadSymbolsSplitter(ui->mainSplitter, "mHSymbolsLogSplitter");
 }
 
-void SymbolView::setModuleSymbols(duint base, const std::vector<void*> & symbols)
+void SymbolView::invalidateSymbolSource(duint base)
 {
-    //TODO: reload actual symbol list, race conditions
-    GuiSymbolLogAdd(QString("[SymbolView] base: %1, count: %2\n").arg(ToPtrString(base)).arg(symbols.size()).toUtf8().constData());
-    mModuleSymbolMap[base] = symbols;
+    QMutexLocker lock(&mSymbolTable->mMutex);
+    for(auto mod : mSymbolTable->mModules)
+    {
+        if(mod == base)
+        {
+            mSymbolTable->mData.clear();
+            mSymbolTable->mData.shrink_to_fit();
+            mSymbolTable->setRowCount(mSymbolTable->mData.size());
+            GuiSymbolLogAdd(QString("[SymbolView] reload symbols for base %1\n").arg(ToPtrString(base)).toUtf8().constData());
+            // TODO: properly reload symbol list
+            break;
+        }
+    }
 }
 
 void SymbolView::setupContextMenu()
@@ -308,66 +318,37 @@ void SymbolView::clearSymbolLogSlot()
     ui->symbolLogEdit->clear();
 }
 
-void SymbolView::cbSymbolEnum(SYMBOLINFO* symbol, void* user)
-{
-    StdTable* symbolList = (StdTable*)user;
-    dsint index = symbolList->getRowCount();
-    symbolList->setRowCount(index + 1);
-    symbolList->setCellContent(index, 0, ToPtrString(symbol->addr));
-    if(symbol->decoratedSymbol)
-    {
-        symbolList->setCellContent(index, 2, symbol->decoratedSymbol);
-    }
-    else
-    {
-        symbolList->setCellContent(index, 2, QString());
-    }
-    if(symbol->undecoratedSymbol)
-    {
-        symbolList->setCellContent(index, 3, symbol->undecoratedSymbol);
-    }
-    else
-    {
-        symbolList->setCellContent(index, 3, QString());
-    }
-
-    if(symbol->isImported)
-    {
-        symbolList->setCellContent(index, 1, tr("Import"));
-    }
-    else
-    {
-        symbolList->setCellContent(index, 1, tr("Export"));
-    }
-}
-
 void SymbolView::moduleSelectionChanged(int index)
 {
     Q_UNUSED(index);
     setUpdatesEnabled(false);
 
-    /*mSearchListView->mList->setRowCount(0);
+    std::vector<duint> selectedModules;
     for(auto index : mModuleList->mCurList->getSelection())
     {
-        QString mod = mModuleList->mCurList->getCellContent(index, 1);
-        if(!mModuleBaseList.count(mod))
-            continue;
-        DbgSymbolEnumFromCache(mModuleBaseList[mod], cbSymbolEnum, mSearchListView->mList);
+        QString modBase = mModuleList->mCurList->getCellContent(index, 0);
+        duint wVA;
+        if(DbgFunctions()->ValFromString(modBase.toUtf8().constData(), &wVA))
+            selectedModules.push_back(wVA);
     }
-    mSearchListView->mList->reloadData();
-    mSearchListView->mList->setSingleSelection(0);
-    mSearchListView->mList->setTableOffset(0);
-    if(!mSearchListView->isSearchBoxLocked())
-        mSearchListView->mSearchBox->setText("");
-    else
-        mSearchListView->refreshSearchList();*/
 
-    QString modBase = mModuleList->mCurList->getCellContent(mModuleList->mCurList->getInitialSelection(), 0);
-    duint wVA;
-    if(!DbgFunctions()->ValFromString(modBase.toUtf8().constData(), &wVA))
-        return;
-    mSymbolTable->mData = mModuleSymbolMap[wVA];
+    std::vector<SYMBOLPTR> data;
+    for(auto base : selectedModules)
+    {
+        DbgSymbolEnum(base, [](const SYMBOLPTR * info, void* userdata)
+        {
+            ((std::vector<SYMBOLPTR>*)userdata)->push_back(*info);
+            return true; // TODO: allow aborting (enumeration in a separate thread)
+        }, &data);
+    }
+
+    mSymbolTable->mMutex.lock();
+    mSymbolTable->mModules = std::move(selectedModules);
+    mSymbolTable->mData = std::move(data);
     mSymbolTable->setRowCount(mSymbolTable->mData.size());
+    mSymbolTable->mMutex.unlock();
+    mSymbolTable->setSingleSelection(0);
+    mSymbolTable->setTableOffset(0);
     mSymbolTable->reloadData();
 
     setUpdatesEnabled(true);

--- a/src/gui/Src/Gui/SymbolView.h
+++ b/src/gui/Src/Gui/SymbolView.h
@@ -25,7 +25,7 @@ public:
     void saveWindowSettings();
     void loadWindowSettings();
 
-    void setModuleSymbols(duint base, const std::vector<void*> & symbols);
+    void invalidateSymbolSource(duint base);
 
 private slots:
     void updateStyle();
@@ -94,8 +94,6 @@ private:
     QAction* mFollowInMemMap;
     QAction* mLoadLib;
     QAction* mFreeLib;
-
-    std::map<duint, std::vector<void*>> mModuleSymbolMap;
 
     static void cbSymbolEnum(SYMBOLINFO* symbol, void* user);
 };

--- a/src/gui/Src/Gui/ZehSymbolTable.cpp
+++ b/src/gui/Src/Gui/ZehSymbolTable.cpp
@@ -1,7 +1,8 @@
 #include "ZehSymbolTable.h"
 
 ZehSymbolTable::ZehSymbolTable(QWidget* parent)
-    : AbstractStdTable(parent)
+    : AbstractStdTable(parent),
+      mMutex(QMutex::Recursive)
 {
     auto charwidth = getCharWidth();
     //enableMultiSelection(true); //TODO
@@ -14,16 +15,27 @@ ZehSymbolTable::ZehSymbolTable(QWidget* parent)
 
 QString ZehSymbolTable::getCellContent(int r, int c)
 {
+    QMutexLocker lock(&mMutex);
     if(!isValidIndex(r, c))
         return QString();
     SYMBOLINFO info = {0};
-    DbgGetSymbolInfo(mData.at(r), &info);
+    DbgGetSymbolInfo(&mData.at(r), &info);
     switch(c)
     {
     case ColAddr:
         return ToPtrString(info.addr);
     case ColType:
-        return info.isImported ? tr("Import") : tr("Export");
+        switch(info.type)
+        {
+        case sym_import:
+            return tr("Import");
+        case sym_export:
+            return tr("Export");
+        case sym_symbol:
+            return tr("Symbol");
+        default:
+            __debugbreak();
+        }
     case ColDecorated:
         return info.decoratedSymbol;
     case ColUndecorated:
@@ -35,16 +47,18 @@ QString ZehSymbolTable::getCellContent(int r, int c)
 
 bool ZehSymbolTable::isValidIndex(int r, int c)
 {
+    QMutexLocker lock(&mMutex);
     return r >= 0 && r < mData.size() && c >= 0 && c <= ColUndecorated;
 }
 
 void ZehSymbolTable::sortRows(int column, bool ascending)
 {
-    std::stable_sort(mData.begin(), mData.end(), [column, ascending](void* a, void* b)
+    QMutexLocker lock(&mMutex);
+    std::stable_sort(mData.begin(), mData.end(), [column, ascending](const SYMBOLPTR & a, const SYMBOLPTR & b)
     {
         SYMBOLINFO ainfo, binfo;
-        DbgGetSymbolInfo(a, &ainfo);
-        DbgGetSymbolInfo(b, &binfo);
+        DbgGetSymbolInfo(&a, &ainfo);
+        DbgGetSymbolInfo(&b, &binfo);
         bool less;
         switch(column)
         {
@@ -52,7 +66,7 @@ void ZehSymbolTable::sortRows(int column, bool ascending)
             less = ainfo.addr < binfo.addr;
             break;
         case ColType:
-            less = ainfo.isImported < binfo.isImported;
+            less = ainfo.type < binfo.type;
             break;
         case ColDecorated:
             less = strcmp(ainfo.decoratedSymbol, binfo.decoratedSymbol) < 0;

--- a/src/gui/Src/Gui/ZehSymbolTable.h
+++ b/src/gui/Src/Gui/ZehSymbolTable.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "AbstractStdTable.h"
+#include <QMutex>
 
 class ZehSymbolTable : public AbstractStdTable
 {
@@ -15,7 +16,9 @@ public:
     friend class SymbolView;
 
 private:
-    std::vector<void*> mData;
+    std::vector<duint> mModules;
+    std::vector<SYMBOLPTR> mData;
+    QMutex mMutex;
 
     enum
     {


### PR DESCRIPTION
Heya,

I've got a few commits for this branch to work on improving the PE parsing (briefly discussed with @mrexodia on IRC). Main changes so far:
- Added `PIMAGE_NT_HEADERS` field to `MODINFO` since this struct is needed by anything related to PE parsing
- Initialize this field (i.e. parse the PE headers) in `GetModuleInfo()`. At the moment the headers are being parsed on _every_ TitanEngine PE helper call (`GetPE32DataFromMappedFile`/`ConvertVAtoFileOffsetEx`), the goal is to reduce that to one time only.
- Added a function to do said parsing: `ImageNtHeaders()`. This is a blatant ripoff of `RtlImageNtHeaderEx`, but that doesn't exist on XP 32 bit.
- Add `RvaToVa()` which basically does what it says for `SEC_COMMIT` images, though so far it is used mostly as a replacement for the `ConvertVAtoFileOffsetEx` calls used by the `rva2offset` lambdas (`RvaToVa` with `base = 0` gives the same result). Ideally both this function and all of the offset conversions should be removed though IMO as using a `SEC_IMAGE` mapping has many benefits over `SEC_COMMIT` including not having to do this. TODO: research memory costs and other potential limitations of this vs. the current method.
- `ReadExportDirectory()` and `ReadImportDirectory()`: both of these were simplified by using `RtlImageDirectoryEntryToData` to get the directory pointer and size directly. Most of the import parsing was rewritten to fix some issues. I also created a lot of broken PE files to try and answer the burning questions re: ntdll loader behaviour...
- `symbolsourcedia.cpp` doesn't have anything to do with this, but it gave me a compile error so I couldn't resist changing some stuff after I opened it.

TODO:
- `ReadTlsCallbacks`, `ReadBaseRelocationTable` and `ReadDebugDirectory` can be improved much in the same way.
- Currently none of the functions are exception-safe other than `ImageNtHeaders`. I'm not really sure what the best way to fix this would be. Using a `SEC_IMAGE` would help a lot as the kernel performs much stricter PE parsing that way, but that still doesn't make you invulnerable. The definitive fix would be to wrap every pointer access in a `try/except` block, but I'm not really a fan of that either. Other than making the code long/tedious/annoying to read, there's also the fact that by the time we get to `GetModuleInfo()`, the debuggee apparently managed to load the DLL successfully. IMO that would make it way more likely that there's a bug in the x64dbg parsing code than there being a problem with the file, and we should fix that instead of returning an error.