### PR TITLE
More PE parsing stuff

### DIFF
--- a/src/bridge/bridgemain.cpp
+++ b/src/bridge/bridgemain.cpp
@@ -1075,9 +1075,9 @@ BRIDGE_IMPEXP void DbgMenuPrepare(int hMenu)
     _dbg_sendmessage(DBG_MENU_PREPARE, (void*)hMenu, nullptr);
 }
 
-BRIDGE_IMPEXP void DbgGetSymbolInfo(void* symbol, SYMBOLINFO* info)
+BRIDGE_IMPEXP void DbgGetSymbolInfo(const SYMBOLPTR* symbolptr, SYMBOLINFO* info)
 {
-    _dbg_sendmessage(DBG_GET_SYMBOL_INFO, symbol, info);
+    _dbg_sendmessage(DBG_GET_SYMBOL_INFO, (void*)symbolptr, info);
 }
 
 BRIDGE_IMPEXP const char* GuiTranslateText(const char* Source)
@@ -1695,9 +1695,9 @@ BRIDGE_IMPEXP void GuiOpenTraceFile(const char* fileName)
     _gui_sendmessage(GUI_OPEN_TRACE_FILE, (void*)fileName, nullptr);
 }
 
-BRIDGE_IMPEXP void GuiSetModuleSymbols(duint base, ListOf(void*) symbols)
+BRIDGE_IMPEXP void GuiInvalidateSymbolSource(duint base)
 {
-    _gui_sendmessage(GUI_SET_MODULE_SYMBOLS, (void*)base, symbols);
+    _gui_sendmessage(GUI_INVALIDATE_SYMBOL_SOURCE, (void*)base, nullptr);
 }
 
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)

--- a/src/bridge/bridgemain.h
+++ b/src/bridge/bridgemain.h
@@ -495,12 +495,19 @@ typedef enum
     hw_qword
 } BPHWSIZE;
 
+typedef enum
+{
+    sym_import,
+    sym_export,
+    sym_symbol
+} SYMBOLTYPE;
+
 //Debugger typedefs
 typedef MEMORY_SIZE VALUE_SIZE;
-typedef struct SYMBOLINFO_ SYMBOLINFO;
+
 typedef struct DBGFUNCTIONS_ DBGFUNCTIONS;
 
-typedef void (*CBSYMBOLENUM)(SYMBOLINFO* symbol, void* user);
+typedef bool (*CBSYMBOLENUM)(const struct SYMBOLPTR_* symbol, void* user);
 
 //Debugger structs
 typedef struct
@@ -583,13 +590,15 @@ typedef struct
     FUNCTION args;
 } BRIDGE_ADDRINFO;
 
-struct SYMBOLINFO_
+typedef struct SYMBOLINFO_
 {
     duint addr;
     char* decoratedSymbol;
     char* undecoratedSymbol;
-    bool isImported;
-};
+    SYMBOLTYPE type;
+    bool freeDecorated;
+    bool freeUndecorated;
+} SYMBOLINFO;
 
 typedef struct
 {
@@ -889,6 +898,12 @@ typedef struct
     XREF_RECORD* references;
 } XREF_INFO;
 
+typedef struct SYMBOLPTR_
+{
+    duint modbase;
+    const void* symbol;
+} SYMBOLPTR;
+
 //Debugger functions
 BRIDGE_IMPEXP const char* DbgInit();
 BRIDGE_IMPEXP void DbgExit();
@@ -1013,7 +1028,7 @@ BRIDGE_IMPEXP duint DbgGetTebAddress(DWORD ThreadId);
 BRIDGE_IMPEXP bool DbgAnalyzeFunction(duint entry, BridgeCFGraphList* graph);
 BRIDGE_IMPEXP duint DbgEval(const char* expression, bool* success = 0);
 BRIDGE_IMPEXP void DbgMenuPrepare(int hMenu);
-BRIDGE_IMPEXP void DbgGetSymbolInfo(void* symbol, SYMBOLINFO* info);
+BRIDGE_IMPEXP void DbgGetSymbolInfo(const SYMBOLPTR* symbolptr, SYMBOLINFO* info);
 
 //Gui defines
 #define GUI_PLUGIN_MENU 0
@@ -1142,7 +1157,7 @@ typedef enum
     GUI_REF_ADDCOMMAND,             // param1=const char* title,    param2=const char* command
     GUI_OPEN_TRACE_FILE,            // param1=const char* file name,param2=unused
     GUI_UPDATE_TRACE_BROWSER,       // param1=unused,               param2=unused
-    GUI_SET_MODULE_SYMBOLS,         // param1=duint base,           param2=ListOf(void*) symbols
+    GUI_INVALIDATE_SYMBOL_SOURCE,   // param1=duint base,           param2=unused
 } GUIMSG;
 
 //GUI Typedefs
@@ -1319,7 +1334,7 @@ BRIDGE_IMPEXP void GuiFlushLog();
 BRIDGE_IMPEXP void GuiReferenceAddCommand(const char* title, const char* command);
 BRIDGE_IMPEXP void GuiUpdateTraceBrowser();
 BRIDGE_IMPEXP void GuiOpenTraceFile(const char* fileName);
-BRIDGE_IMPEXP void GuiSetModuleSymbols(duint base, ListOf(void*) symbols);
+BRIDGE_IMPEXP void GuiInvalidateSymbolSource(duint base);
 
 #ifdef __cplusplus
 }

--- a/src/dbg/dbghelp_safe.h
+++ b/src/dbg/dbghelp_safe.h
@@ -10,13 +10,13 @@
 void SafeDbghelpInitialize();
 void SafeDbghelpDeinitialize();
 
-DWORD
+/*DWORD
 SafeUnDecorateSymbolName(
     __in PCSTR name,
     __out_ecount(maxStringLength) PSTR outputString,
     __in DWORD maxStringLength,
     __in DWORD flags
-);
+);*/
 BOOL
 SafeSymUnloadModule64(
     __in HANDLE hProcess,

--- a/src/dbg/memory.cpp
+++ b/src/dbg/memory.cpp
@@ -153,7 +153,7 @@ void MemUpdateMap()
         {
             duint start = (duint)currentPage.mbi.BaseAddress;
             duint end = start + currentPage.mbi.RegionSize;
-            for(int j = 0, k = 0; j < SectionNumber; j++)
+            for(duint j = 0, k = 0; (j < (duint)SectionNumber) && (k + IMAGE_SIZEOF_SHORT_NAME < MAX_MODULE_SIZE); j++)
             {
                 const auto & currentSection = sections.at(j);
                 duint secStart = currentSection.addr;

--- a/src/dbg/module.cpp
+++ b/src/dbg/module.cpp
@@ -275,78 +275,69 @@ static void ReadBaseRelocationTable(MODINFO & Info, ULONG_PTR FileMapVA)
     // Clear relocations
     Info.relocations.clear();
 
-    // Parse base relocation table
-    duint characteristics = GetPE32DataFromMappedFile(FileMapVA, 0, UE_CHARACTERISTICS);
-    if((characteristics & IMAGE_FILE_RELOCS_STRIPPED) == IMAGE_FILE_RELOCS_STRIPPED)
+    // Ignore files with relocation info stripped
+    if((Info.headers->FileHeader.Characteristics & IMAGE_FILE_RELOCS_STRIPPED) == IMAGE_FILE_RELOCS_STRIPPED)
         return;
 
     // Get address and size of base relocation table
-    duint relocDirRva = GetPE32DataFromMappedFile(FileMapVA, 0, UE_RELOCATIONTABLEADDRESS);
-    duint relocDirSize = GetPE32DataFromMappedFile(FileMapVA, 0, UE_RELOCATIONTABLESIZE);
-    if(relocDirRva == 0 || relocDirSize == 0)
+    ULONG totalBytes;
+    auto baseRelocBlock = (PIMAGE_BASE_RELOCATION)RtlImageDirectoryEntryToData((PVOID)FileMapVA,
+                          FALSE,
+                          IMAGE_DIRECTORY_ENTRY_BASERELOC,
+                          &totalBytes);
+    if(baseRelocBlock == nullptr || totalBytes == 0 || (ULONG_PTR)baseRelocBlock + totalBytes > FileMapVA + Info.loadedSize)
         return;
 
-    auto relocDirOffset = (duint)ConvertVAtoFileOffsetEx(FileMapVA, Info.loadedSize, 0, relocDirRva, true, false);
-    if(!relocDirOffset || relocDirOffset + relocDirSize > Info.loadedSize)
+    // Until we reach the end of the relocation table
+    while(totalBytes > 0)
     {
-        dprintf(QT_TRANSLATE_NOOP("DBG", "Invalid relocation directory for module %s%s...\n"), Info.name, Info.extension);
-        return;
-    }
-
-    auto read = [&](duint offset, void* dest, size_t size)
-    {
-        if(offset + size > Info.loadedSize)
-            return false;
-        memcpy(dest, (char*)FileMapVA + offset, size);
-        return true;
-    };
-
-    duint curPos = relocDirOffset;
-    // Until we reach the end of base relocation table
-    while(curPos < relocDirOffset + relocDirSize)
-    {
-        // Read base relocation block header
-        IMAGE_BASE_RELOCATION baseRelocBlock;
-        if(!read(curPos, &baseRelocBlock, sizeof(baseRelocBlock)))
+        ULONG blockSize = baseRelocBlock->SizeOfBlock;
+        if(blockSize == 0 || blockSize > totalBytes) // The loader allows incorrect relocation dir sizes/block counts, but it won't relocate the image
         {
-            dprintf(QT_TRANSLATE_NOOP("DBG", "Invalid relocation block for module %s%s...\n"), Info.name, Info.extension);
+            dprintf(QT_TRANSLATE_NOOP("DBG", "Invalid relocation block for module %s%s!\n"), Info.name, Info.extension);
             return;
         }
 
-        // For every entry in base relocation block
-        duint count = (baseRelocBlock.SizeOfBlock - 8) / 2;
-        for(duint i = 0; i < count; i++)
+        // Process the relocation block
+        totalBytes -= blockSize;
+        blockSize = (blockSize - sizeof(IMAGE_BASE_RELOCATION)) / sizeof(USHORT);
+        PUSHORT nextOffset = (PUSHORT)((PCHAR)baseRelocBlock + sizeof(IMAGE_BASE_RELOCATION));
+
+        while(blockSize--)
         {
-            uint16 data = 0;
-            if(!read(curPos + 8 + 2 * i, &data, sizeof(uint16)))
+            const auto type = (UCHAR)((*nextOffset) >> 12);
+            const auto offset = (USHORT)(*nextOffset & 0xfff);
+
+            if(baseRelocBlock->VirtualAddress + offset > FileMapVA + HEADER_FIELD(Info.headers, SizeOfImage))
             {
-                dprintf(QT_TRANSLATE_NOOP("DBG", "Invalid relocation entry for module %s%s...\n"), Info.name, Info.extension);
+                dprintf(QT_TRANSLATE_NOOP("DBG", "Invalid relocation entry for module %s%s!\n"), Info.name, Info.extension);
                 return;
             }
-
-            auto type = (data & 0xF000) >> 12;
-            auto offset = data & 0x0FFF;
 
             switch(type)
             {
             case IMAGE_REL_BASED_HIGHLOW:
-                Info.relocations.push_back(MODRELOCATIONINFO{ baseRelocBlock.VirtualAddress + offset, (BYTE)type, 4 });
+                Info.relocations.push_back(MODRELOCATIONINFO{ baseRelocBlock->VirtualAddress + offset, type, sizeof(ULONG) });
                 break;
             case IMAGE_REL_BASED_DIR64:
-                Info.relocations.push_back(MODRELOCATIONINFO{ baseRelocBlock.VirtualAddress + offset, (BYTE)type, 8 });
+                Info.relocations.push_back(MODRELOCATIONINFO{ baseRelocBlock->VirtualAddress + offset, type, sizeof(ULONG64) });
                 break;
             case IMAGE_REL_BASED_HIGH:
             case IMAGE_REL_BASED_LOW:
             case IMAGE_REL_BASED_HIGHADJ:
-                Info.relocations.push_back(MODRELOCATIONINFO{ baseRelocBlock.VirtualAddress + offset, (BYTE)type, 2 });
+                Info.relocations.push_back(MODRELOCATIONINFO{ baseRelocBlock->VirtualAddress + offset, type, sizeof(USHORT) });
                 break;
             case IMAGE_REL_BASED_ABSOLUTE:
-            default:
+            case IMAGE_REL_BASED_RESERVED: // IMAGE_REL_BASED_SECTION; ignored by loader
+            case IMAGE_REL_BASED_MACHINE_SPECIFIC_7: // IMAGE_REL_BASED_REL32; ignored by loader
                 break;
+            default:
+                dprintf(QT_TRANSLATE_NOOP("DBG", "Illegal relocation type 0x%02X for module %s%s!\n"), type, Info.name, Info.extension);
+                return;
             }
+            ++nextOffset;
         }
-
-        curPos += baseRelocBlock.SizeOfBlock;
+        baseRelocBlock = (PIMAGE_BASE_RELOCATION)nextOffset;
     }
 
     std::sort(Info.relocations.begin(), Info.relocations.end(), [](MODRELOCATIONINFO const & a, MODRELOCATIONINFO const & b)

--- a/src/dbg/module.cpp
+++ b/src/dbg/module.cpp
@@ -567,8 +567,9 @@ void GetModuleInfo(MODINFO & Info, ULONG_PTR FileMapVA)
     }
 
     // Enumerate all PE sections
-    Info.sections.clear();
     WORD sectionCount = Info.headers->FileHeader.NumberOfSections;
+    Info.sections.clear();
+    Info.sections.reserve(sectionCount);
     PIMAGE_SECTION_HEADER ntSection = IMAGE_FIRST_SECTION(Info.headers);
 
     for(WORD i = 0; i < sectionCount; i++)

--- a/src/dbg/pdbdiafile.cpp
+++ b/src/dbg/pdbdiafile.cpp
@@ -353,6 +353,7 @@ bool PDBDiaFile::open(const wchar_t* file, uint64_t loadAddress, DiaValidationDa
             }
 
             // NOTE: For some reason this never matches, commented for now.
+            // ^ 99% sure this should only be used for PDB v2.0 ('NB10' ones). v7.0 PDBs should be checked using (age+guid) only
             /*
             DWORD signature = 0;
             hr = globalSym->get_signature(&signature);

--- a/src/dbg/pdbdiafile.cpp
+++ b/src/dbg/pdbdiafile.cpp
@@ -115,11 +115,7 @@ public:
         if(hFile == INVALID_HANDLE_VALUE)
             return HRESULT_FROM_WIN32(GetLastError());
 
-        DiaFileStream* out = new DiaFileStream(hFile);
-        *ppStream = out;
-
-        if(*ppStream == NULL)
-            CloseHandle(hFile);
+        *ppStream = new DiaFileStream(hFile);
 
         return S_OK;
     }
@@ -391,25 +387,21 @@ bool PDBDiaFile::open(const wchar_t* file, uint64_t loadAddress, DiaValidationDa
 
 bool PDBDiaFile::isOpen() const
 {
-    return m_session != nullptr && m_dataSource != nullptr;
+    return m_session != nullptr || m_dataSource != nullptr;
 }
 
 bool PDBDiaFile::close()
 {
-    if(m_dataSource == nullptr)
-        return false;
-    if(m_session == nullptr)
-        return false;
-
-    m_session->Release();
-    m_dataSource->Release();
-    m_session = nullptr;
-    m_dataSource = nullptr;
-
-    if(m_stream != nullptr)
+    if(m_session)
     {
-        delete(DiaFileStream*)m_stream;
-        m_stream = nullptr;
+        m_session->Release();
+        m_session = nullptr;
+    }
+
+    if(m_dataSource)
+    {
+        m_dataSource->Release();
+        m_dataSource = nullptr;
     }
 
     return true;

--- a/src/dbg/symbolsourcebase.h
+++ b/src/dbg/symbolsourcebase.h
@@ -7,19 +7,33 @@
 #include <vector>
 #include <functional>
 
-struct SymbolInfo
+struct SymbolInfoGui
 {
-    duint va;
+    virtual void convertToGuiSymbol(duint base, SYMBOLINFO* info) const = 0;
+};
+
+struct SymbolInfo : SymbolInfoGui
+{
+    duint rva;
     duint size;
     int32 disp;
     String decoratedName;
     String undecoratedName;
     bool publicSymbol;
+
+    void convertToGuiSymbol(duint modbase, SYMBOLINFO* info) const override
+    {
+        info->addr = modbase + this->rva;
+        info->decoratedSymbol = (char*)this->decoratedName.c_str();
+        info->undecoratedSymbol = (char*)this->undecoratedName.c_str();
+        info->type = sym_symbol;
+        info->freeDecorated = info->freeUndecorated = false;
+    }
 };
 
 struct LineInfo
 {
-    duint addr;
+    duint rva;
     duint size;
     duint disp;
     int lineNumber;
@@ -89,6 +103,7 @@ public:
         return false; // Stub
     }
 
+    // only call if isOpen && !isLoading
     virtual void enumSymbols(const CbEnumSymbol & cbEnum)
     {
         // Stub

--- a/src/dbg/symbolsourcedia.h
+++ b/src/dbg/symbolsourcedia.h
@@ -102,6 +102,7 @@ private:
     duint _imageBase;
     duint _imageSize;
     SpinLock _lockSymbols;
+    bool _symbolsLoaded = false;
     SpinLock _lockLines;
 
 private:

--- a/src/dbg/symcache.cpp
+++ b/src/dbg/symcache.cpp
@@ -39,7 +39,7 @@ bool SymbolFromAddressExact(duint address, SymbolInfo & symInfo)
             if(found != modInfo->exportsByRva.end())
             {
                 auto & modExport = modInfo->exports.at(*found);
-                symInfo.va = modExport.rva + modInfo->base;
+                symInfo.rva = modExport.rva;
                 symInfo.size = 0;
                 symInfo.disp = 0;
                 symInfo.decoratedName = modExport.name;

--- a/src/gui/Src/BasicView/AbstractStdTable.h
+++ b/src/gui/Src/BasicView/AbstractStdTable.h
@@ -69,12 +69,14 @@ public slots:
 protected:
     QString copyTable(const std::vector<int> & colWidths);
 
-    struct
+    struct SelectionData_t
     {
         int firstSelectedIndex = 0;
         int fromIndex = 0;
         int toIndex = 0;
-    } mSelection;
+    };
+
+    SelectionData_t mSelection;
 
     enum
     {

--- a/src/gui/Src/BasicView/AbstractTableView.h
+++ b/src/gui/Src/BasicView/AbstractTableView.h
@@ -75,7 +75,7 @@ public:
 
     // New Columns/New Size
     virtual void addColumnAt(int width, const QString & title, bool isClickable);
-    virtual void setRowCount(dsint count);
+    virtual void setRowCount(dsint count); // TODO: why is this virtual?
     virtual void deleteAllColumns();
     void setColTitle(int index, const QString & title);
     QString getColTitle(int index);

--- a/src/gui/Src/BasicView/SearchListViewSymbols.cpp
+++ b/src/gui/Src/BasicView/SearchListViewSymbols.cpp
@@ -2,10 +2,10 @@
 #include <QHBoxLayout>
 #include <QSplitter>
 #include <QLabel>
-#include "SearchListView.h"
+#include "SearchListViewSymbols.h"
 #include "FlickerThread.h"
 
-SearchListView::SearchListView(bool EnableRegex, QWidget* parent, bool EnableLock) : QWidget(parent)
+SearchListViewSymbols::SearchListViewSymbols(bool EnableRegex, QWidget* parent, bool EnableLock) : QWidget(parent)
 {
     setContextMenuPolicy(Qt::CustomContextMenu);
 
@@ -20,8 +20,8 @@ SearchListView::SearchListView(bool EnableRegex, QWidget* parent, bool EnableLoc
         // Create list layout (contains both ListViews)
         {
             // Create reference & search list
-            mList = new SearchListViewTable();
-            mSearchList = new SearchListViewTable();
+            mList = new ZehSymbolTable();
+            mSearchList = new ZehSymbolTable();
             mSearchList->hide();
 
             // Vertical layout
@@ -115,11 +115,11 @@ SearchListView::SearchListView(bool EnableRegex, QWidget* parent, bool EnableLoc
     mList->setFocusProxy(mSearchBox);
 }
 
-SearchListView::~SearchListView()
+SearchListViewSymbols::~SearchListViewSymbols()
 {
 }
 
-bool SearchListView::findTextInList(SearchListViewTable* list, QString text, int row, int startcol, bool startswith)
+bool SearchListViewSymbols::findTextInList(ZehSymbolTable* list, QString text, int row, int startcol, bool startswith)
 {
     int count = list->getColumnCount();
     if(startcol + 1 > count)
@@ -150,9 +150,12 @@ bool SearchListView::findTextInList(SearchListViewTable* list, QString text, int
     return false;
 }
 
-void SearchListView::searchTextChanged(const QString & arg1)
+void SearchListViewSymbols::searchTextChanged(const QString & arg1)
 {
-    SearchListViewTable* mPrevList = NULL;
+    QMutexLocker lock1(&mList->mMutex);
+    QMutexLocker lock2(&mSearchList->mMutex);
+
+    ZehSymbolTable* mPrevList = NULL;
 
     // TODO: use mCurList ?
     QString mLastFirstColValue;
@@ -189,15 +192,16 @@ void SearchListView::searchTextChanged(const QString & arg1)
     }
 
     mSearchList->setRowCount(0);
+    mSearchList->mData.clear();
+    mSearchList->mData.reserve(mList->mData.size());
+    mSearchList->mModules = mList->mModules;
     int rows = mList->getRowCount();
-    int columns = mList->getColumnCount();
     for(int i = 0, j = 0; i < rows; i++)
     {
         if(findTextInList(mList, arg1, i, mSearchStartCol, false))
         {
             mSearchList->setRowCount(j + 1);
-            for(int k = 0; k < columns; k++)
-                mSearchList->setCellContent(j, k, mList->getCellContent(i, k));
+            mSearchList->mData.push_back(mList->mData.at(i));
             j++;
         }
     }
@@ -251,12 +255,12 @@ void SearchListView::searchTextChanged(const QString & arg1)
     }
 }
 
-void SearchListView::refreshSearchList()
+void SearchListViewSymbols::refreshSearchList()
 {
     searchTextChanged(mSearchBox->text());
 }
 
-void SearchListView::listContextMenu(const QPoint & pos)
+void SearchListViewSymbols::listContextMenu(const QPoint & pos)
 {
     QMenu wMenu(this);
     emit listContextMenuSignal(&wMenu);
@@ -270,28 +274,28 @@ void SearchListView::listContextMenu(const QPoint & pos)
     wMenu.exec(mCurList->mapToGlobal(pos));
 }
 
-void SearchListView::doubleClickedSlot()
+void SearchListViewSymbols::doubleClickedSlot()
 {
     emit enterPressedSignal();
 }
 
-void SearchListView::on_checkBoxRegex_stateChanged(int state)
+void SearchListViewSymbols::on_checkBoxRegex_stateChanged(int state)
 {
     Q_UNUSED(state);
     refreshSearchList();
 }
 
-void SearchListView::on_checkBoxLock_toggled(bool checked)
+void SearchListViewSymbols::on_checkBoxLock_toggled(bool checked)
 {
     mSearchBox->setDisabled(checked);
 }
 
-bool SearchListView::isSearchBoxLocked()
+bool SearchListViewSymbols::isSearchBoxLocked()
 {
     return mLockCheckbox->isChecked();
 }
 
-bool SearchListView::eventFilter(QObject* obj, QEvent* event)
+bool SearchListViewSymbols::eventFilter(QObject* obj, QEvent* event)
 {
     // Keyboard button press being sent to the QLineEdit
     if(obj == mSearchBox && event->type() == QEvent::KeyPress)
@@ -342,7 +346,7 @@ bool SearchListView::eventFilter(QObject* obj, QEvent* event)
     return QWidget::eventFilter(obj, event);
 }
 
-void SearchListView::searchSlot()
+void SearchListViewSymbols::searchSlot()
 {
     FlickerThread* thread = new FlickerThread(mSearchBox, this);
     connect(thread, SIGNAL(setStyleSheet(QString)), mSearchBox, SLOT(setStyleSheet(QString)));

--- a/src/gui/Src/BasicView/SearchListViewSymbols.h
+++ b/src/gui/Src/BasicView/SearchListViewSymbols.h
@@ -1,33 +1,28 @@
-#ifndef SEARCHLISTVIEW_H
-#define SEARCHLISTVIEW_H
+#ifndef SEARCHLISTVIEWSYMBOLS_H
+#define SEARCHLISTVIEWSYMBOLS_H
 
 #include <QWidget>
 #include <QLineEdit>
 #include <QCheckBox>
-#include "SearchListViewTable.h"
+#include "ZehSymbolTable.h"
 #include "MenuBuilder.h"
 #include "ActionHelpers.h"
 
-namespace Ui
-{
-    class SearchListView;
-}
-
-class SearchListView : public QWidget, public ActionHelper<SearchListView>
+class SearchListViewSymbols : public QWidget, public ActionHelper<SearchListViewSymbols>
 {
     Q_OBJECT
 
 public:
-    explicit SearchListView(bool EnableRegex = true, QWidget* parent = 0, bool EnableLock = false);
-    ~SearchListView();
+    explicit SearchListViewSymbols(bool EnableRegex = true, QWidget* parent = 0, bool EnableLock = false);
+    ~SearchListViewSymbols();
 
-    SearchListViewTable* mList;
-    SearchListViewTable* mSearchList;
-    SearchListViewTable* mCurList;
+    ZehSymbolTable* mList;
+    ZehSymbolTable* mSearchList;
+    ZehSymbolTable* mCurList;
     QLineEdit* mSearchBox;
     int mSearchStartCol;
 
-    bool findTextInList(SearchListViewTable* list, QString text, int row, int startcol, bool startswith);
+    bool findTextInList(ZehSymbolTable* list, QString text, int row, int startcol, bool startswith);
     void refreshSearchList();
 
     bool isSearchBoxLocked();
@@ -54,4 +49,4 @@ private:
     QAction* mSearchAction;
 };
 
-#endif // SEARCHLISTVIEW_H
+#endif // SEARCHLISTVIEWSYMBOLS_H

--- a/src/gui/Src/Bridge/Bridge.cpp
+++ b/src/gui/Src/Bridge/Bridge.cpp
@@ -840,10 +840,8 @@ void* Bridge::processMessage(GUIMSG type, void* param1, void* param2)
         emit updateTraceBrowser();
         break;
 
-    case GUI_SET_MODULE_SYMBOLS:
-        std::vector<void*> moduleSymbols;
-        BridgeList<void*>::ToVector((const ListInfo*)param2, moduleSymbols, false);
-        symbolView->setModuleSymbols(duint(param1), moduleSymbols);
+    case GUI_INVALIDATE_SYMBOL_SOURCE:
+        symbolView->invalidateSymbolSource(duint(param1));
         break;
     }
 

--- a/src/gui/Src/Gui/SymbolView.cpp
+++ b/src/gui/Src/Gui/SymbolView.cpp
@@ -8,6 +8,7 @@
 #include "LineEditDialog.h"
 #include "BrowseDialog.h"
 #include "SearchListView.h"
+#include "SearchListViewSymbols.h"
 #include <QVBoxLayout>
 #include <QProcess>
 #include <QFileDialog>
@@ -23,13 +24,9 @@ SymbolView::SymbolView(QWidget* parent) : QWidget(parent), ui(new Ui::SymbolView
     mMainLayout->addWidget(ui->mainSplitter);
     setLayout(mMainLayout);
 
-    // Create symbol table
-    mSymbolTable = new ZehSymbolTable(this);
-
     // Create reference view
-    mSearchListView = new SearchListView(true, this, true);
+    mSearchListView = new SearchListViewSymbols(true, this, true);
     mSearchListView->mSearchStartCol = 1;
-    mSearchListView->setVisible(false);
 
     // Create module list
     mModuleList = new SearchListView(true, this);
@@ -49,25 +46,9 @@ SymbolView::SymbolView(QWidget* parent) : QWidget(parent), ui(new Ui::SymbolView
     mModuleList->mSearchList->addColumnAt(charwidth * 60, tr("Path"), true);
     mModuleList->mSearchList->loadColumnFromConfig("Module");
 
-    // Setup symbol list
-    mSearchListView->mList->enableMultiSelection(true);
-    mSearchListView->mList->addColumnAt(charwidth * 2 * sizeof(dsint) + 8, tr("Address"), true);
-    mSearchListView->mList->addColumnAt(charwidth * 6 + 8, tr("Type"), true);
-    mSearchListView->mList->addColumnAt(charwidth * 80, tr("Symbol"), true);
-    mSearchListView->mList->addColumnAt(2000, tr("Symbol (undecorated)"), true);
-    mSearchListView->mList->loadColumnFromConfig("Symbol");
-
-    // Setup search list
-    mSearchListView->mSearchList->enableMultiSelection(true);
-    mSearchListView->mSearchList->addColumnAt(charwidth * 2 * sizeof(dsint) + 8, tr("Address"), true);
-    mSearchListView->mSearchList->addColumnAt(charwidth * 6 + 8, tr("Type"), true);
-    mSearchListView->mSearchList->addColumnAt(charwidth * 80, tr("Symbol"), true);
-    mSearchListView->mSearchList->addColumnAt(2000, tr("Symbol (undecorated)"), true);
-    mSearchListView->mSearchList->loadColumnFromConfig("Symbol");
-
     // Setup list splitter
     ui->listSplitter->addWidget(mModuleList);
-    ui->listSplitter->addWidget(mSymbolTable);
+    ui->listSplitter->addWidget(mSearchListView);
 #ifdef _WIN64
     // mModuleList : mSymbolList = 40 : 100
     ui->listSplitter->setStretchFactor(0, 40);
@@ -145,11 +126,26 @@ void SymbolView::loadWindowSettings()
     loadSymbolsSplitter(ui->mainSplitter, "mHSymbolsLogSplitter");
 }
 
-void SymbolView::setModuleSymbols(duint base, const std::vector<void*> & symbols)
+void SymbolView::invalidateSymbolSource(duint base)
 {
-    //TODO: reload actual symbol list, race conditions
-    GuiSymbolLogAdd(QString("[SymbolView] base: %1, count: %2\n").arg(ToPtrString(base)).arg(symbols.size()).toUtf8().constData());
-    mModuleSymbolMap[base] = symbols;
+    QMutexLocker lock1(&mSearchListView->mList->mMutex);
+    QMutexLocker lock2(&mSearchListView->mSearchList->mMutex);
+    for(auto mod : mSearchListView->mList->mModules)
+    {
+        if(mod == base)
+        {
+            mSearchListView->mList->mData.clear();
+            mSearchListView->mList->mData.shrink_to_fit();
+            mSearchListView->mList->setRowCount(0);
+            mSearchListView->mSearchList->mData.clear();
+            mSearchListView->mSearchList->mData.shrink_to_fit();
+            mSearchListView->mSearchList->setRowCount(0);
+            mSearchListView->mSearchList->highlightText.clear();
+            GuiSymbolLogAdd(QString("[SymbolView] reload symbols for base %1\n").arg(ToPtrString(base)).toUtf8().constData());
+            // TODO: properly reload symbol list
+            break;
+        }
+    }
 }
 
 void SymbolView::setupContextMenu()
@@ -308,67 +304,44 @@ void SymbolView::clearSymbolLogSlot()
     ui->symbolLogEdit->clear();
 }
 
-void SymbolView::cbSymbolEnum(SYMBOLINFO* symbol, void* user)
-{
-    StdTable* symbolList = (StdTable*)user;
-    dsint index = symbolList->getRowCount();
-    symbolList->setRowCount(index + 1);
-    symbolList->setCellContent(index, 0, ToPtrString(symbol->addr));
-    if(symbol->decoratedSymbol)
-    {
-        symbolList->setCellContent(index, 2, symbol->decoratedSymbol);
-    }
-    else
-    {
-        symbolList->setCellContent(index, 2, QString());
-    }
-    if(symbol->undecoratedSymbol)
-    {
-        symbolList->setCellContent(index, 3, symbol->undecoratedSymbol);
-    }
-    else
-    {
-        symbolList->setCellContent(index, 3, QString());
-    }
-
-    if(symbol->isImported)
-    {
-        symbolList->setCellContent(index, 1, tr("Import"));
-    }
-    else
-    {
-        symbolList->setCellContent(index, 1, tr("Export"));
-    }
-}
-
 void SymbolView::moduleSelectionChanged(int index)
 {
     Q_UNUSED(index);
     setUpdatesEnabled(false);
 
-    /*mSearchListView->mList->setRowCount(0);
+    std::vector<duint> selectedModules;
     for(auto index : mModuleList->mCurList->getSelection())
     {
-        QString mod = mModuleList->mCurList->getCellContent(index, 1);
-        if(!mModuleBaseList.count(mod))
-            continue;
-        DbgSymbolEnumFromCache(mModuleBaseList[mod], cbSymbolEnum, mSearchListView->mList);
+        QString modBase = mModuleList->mCurList->getCellContent(index, 0);
+        duint wVA;
+        if(DbgFunctions()->ValFromString(modBase.toUtf8().constData(), &wVA))
+            selectedModules.push_back(wVA);
     }
-    mSearchListView->mList->reloadData();
+
+    std::vector<SYMBOLPTR> data;
+    for(auto base : selectedModules)
+    {
+        DbgSymbolEnum(base, [](const SYMBOLPTR * info, void* userdata)
+        {
+            ((std::vector<SYMBOLPTR>*)userdata)->push_back(*info);
+            return true; // TODO: allow aborting (enumeration in a separate thread)
+        }, &data);
+    }
+
+    mSearchListView->mList->mMutex.lock();
+    mSearchListView->mSearchList->mMutex.lock();
+    mSearchListView->mList->mModules = std::move(selectedModules);
+    mSearchListView->mList->mData = std::move(data);
+    mSearchListView->mList->setRowCount(mSearchListView->mList->mData.size());
+    mSearchListView->mSearchList->mMutex.unlock();
+    mSearchListView->mList->mMutex.unlock();
     mSearchListView->mList->setSingleSelection(0);
     mSearchListView->mList->setTableOffset(0);
+    mSearchListView->mList->reloadData();
     if(!mSearchListView->isSearchBoxLocked())
         mSearchListView->mSearchBox->setText("");
     else
-        mSearchListView->refreshSearchList();*/
-
-    QString modBase = mModuleList->mCurList->getCellContent(mModuleList->mCurList->getInitialSelection(), 0);
-    duint wVA;
-    if(!DbgFunctions()->ValFromString(modBase.toUtf8().constData(), &wVA))
-        return;
-    mSymbolTable->mData = mModuleSymbolMap[wVA];
-    mSymbolTable->setRowCount(mSymbolTable->mData.size());
-    mSymbolTable->reloadData();
+        mSearchListView->refreshSearchList();
 
     setUpdatesEnabled(true);
 }

--- a/src/gui/Src/Gui/SymbolView.h
+++ b/src/gui/Src/Gui/SymbolView.h
@@ -3,10 +3,10 @@
 
 #include <QWidget>
 #include "Bridge.h"
-#include "ZehSymbolTable.h"
 
 class QMenu;
 class SearchListView;
+class SearchListViewSymbols;
 class QVBoxLayout;
 
 namespace Ui
@@ -25,7 +25,7 @@ public:
     void saveWindowSettings();
     void loadWindowSettings();
 
-    void setModuleSymbols(duint base, const std::vector<void*> & symbols);
+    void invalidateSymbolSource(duint base);
 
 private slots:
     void updateStyle();
@@ -70,9 +70,8 @@ private:
     QVBoxLayout* mMainLayout;
     QVBoxLayout* mSymbolLayout;
     QWidget* mSymbolPlaceHolder;
-    SearchListView* mSearchListView;
+    SearchListViewSymbols* mSearchListView;
     SearchListView* mModuleList;
-    ZehSymbolTable* mSymbolTable;
     QMap<QString, duint> mModuleBaseList;
     QAction* mFollowSymbolAction;
     QAction* mFollowSymbolDumpAction;
@@ -94,8 +93,6 @@ private:
     QAction* mFollowInMemMap;
     QAction* mLoadLib;
     QAction* mFreeLib;
-
-    std::map<duint, std::vector<void*>> mModuleSymbolMap;
 
     static void cbSymbolEnum(SYMBOLINFO* symbol, void* user);
 };

--- a/src/gui/Src/Gui/ZehSymbolTable.cpp
+++ b/src/gui/Src/Gui/ZehSymbolTable.cpp
@@ -1,29 +1,44 @@
 #include "ZehSymbolTable.h"
+#include "Bridge.h"
+#include "RichTextPainter.h"
 
 ZehSymbolTable::ZehSymbolTable(QWidget* parent)
-    : AbstractStdTable(parent)
+    : AbstractStdTable(parent),
+      mMutex(QMutex::Recursive)
 {
     auto charwidth = getCharWidth();
-    //enableMultiSelection(true); //TODO
+    enableMultiSelection(true);
     addColumnAt(charwidth * 2 * sizeof(dsint) + 8, tr("Address"), true);
     addColumnAt(charwidth * 6 + 8, tr("Type"), true);
     addColumnAt(charwidth * 80, tr("Symbol"), true);
     addColumnAt(2000, tr("Symbol (undecorated)"), true);
-    //loadColumnFromConfig("Symbol"); //TODO
+    loadColumnFromConfig("Symbol");
+    updateColors();
 }
 
 QString ZehSymbolTable::getCellContent(int r, int c)
 {
+    QMutexLocker lock(&mMutex);
     if(!isValidIndex(r, c))
         return QString();
     SYMBOLINFO info = {0};
-    DbgGetSymbolInfo(mData.at(r), &info);
+    DbgGetSymbolInfo(&mData.at(r), &info);
     switch(c)
     {
     case ColAddr:
         return ToPtrString(info.addr);
     case ColType:
-        return info.isImported ? tr("Import") : tr("Export");
+        switch(info.type)
+        {
+        case sym_import:
+            return tr("Import");
+        case sym_export:
+            return tr("Export");
+        case sym_symbol:
+            return tr("Symbol");
+        default:
+            __debugbreak();
+        }
     case ColDecorated:
         return info.decoratedSymbol;
     case ColUndecorated:
@@ -35,16 +50,18 @@ QString ZehSymbolTable::getCellContent(int r, int c)
 
 bool ZehSymbolTable::isValidIndex(int r, int c)
 {
+    QMutexLocker lock(&mMutex);
     return r >= 0 && r < mData.size() && c >= 0 && c <= ColUndecorated;
 }
 
 void ZehSymbolTable::sortRows(int column, bool ascending)
 {
-    std::stable_sort(mData.begin(), mData.end(), [column, ascending](void* a, void* b)
+    QMutexLocker lock(&mMutex);
+    std::stable_sort(mData.begin(), mData.end(), [column, ascending](const SYMBOLPTR & a, const SYMBOLPTR & b)
     {
         SYMBOLINFO ainfo, binfo;
-        DbgGetSymbolInfo(a, &ainfo);
-        DbgGetSymbolInfo(b, &binfo);
+        DbgGetSymbolInfo(&a, &ainfo);
+        DbgGetSymbolInfo(&b, &binfo);
         bool less;
         switch(column)
         {
@@ -52,7 +69,7 @@ void ZehSymbolTable::sortRows(int column, bool ascending)
             less = ainfo.addr < binfo.addr;
             break;
         case ColType:
-            less = ainfo.isImported < binfo.isImported;
+            less = ainfo.type < binfo.type;
             break;
         case ColDecorated:
             less = strcmp(ainfo.decoratedSymbol, binfo.decoratedSymbol) < 0;
@@ -63,4 +80,297 @@ void ZehSymbolTable::sortRows(int column, bool ascending)
         }
         return ascending ? less : !less;
     });
+}
+
+QString ZehSymbolTable::paintContent(QPainter* painter, dsint rowBase, int rowOffset, int col, int x, int y, int w, int h)
+{
+    bool isaddr = true;
+    bool wIsSelected = isSelected(rowBase, rowOffset);
+    QString text = getCellContent(rowBase + rowOffset, col);
+    if(!DbgIsDebugging())
+        isaddr = false;
+    if(!getRowCount())
+        isaddr = false;
+
+    duint wVA = duint(text.toULongLong(&isaddr, 16));
+    auto wIsTraced = isaddr && DbgFunctions()->GetTraceRecordHitCount(wVA) != 0;
+    QColor lineBackgroundColor;
+    bool isBackgroundColorSet;
+    if(wIsSelected && wIsTraced)
+    {
+        lineBackgroundColor = mTracedSelectedAddressBackgroundColor;
+        isBackgroundColorSet = true;
+    }
+    else if(wIsSelected)
+    {
+        lineBackgroundColor = selectionColor;
+        isBackgroundColorSet = true;
+    }
+    else if(wIsTraced)
+    {
+        lineBackgroundColor = mTracedBackgroundColor;
+        isBackgroundColorSet = true;
+    }
+    else
+    {
+        isBackgroundColorSet = false;
+    }
+    if(isBackgroundColorSet)
+        painter->fillRect(QRect(x, y, w, h), QBrush(lineBackgroundColor));
+
+    if(col == ColAddr && isaddr)
+    {
+        char label[MAX_LABEL_SIZE] = "";
+        if(DbgGetLabelAt(wVA, SEG_DEFAULT, label)) //has label
+        {
+            char module[MAX_MODULE_SIZE] = "";
+            if(DbgGetModuleAt(wVA, module) && !QString(label).startsWith("JMP.&"))
+                text += " <" + QString(module) + "." + QString(label) + ">";
+            else
+                text += " <" + QString(label) + ">";
+        }
+        BPXTYPE bpxtype = DbgGetBpxTypeAt(wVA);
+        bool isbookmark = DbgGetBookmarkAt(wVA);
+
+        duint cip = Bridge::getBridge()->mLastCip;
+        if(bCipBase)
+        {
+            duint base = DbgFunctions()->ModBaseFromAddr(cip);
+            if(base)
+                cip = base;
+        }
+
+        if(DbgIsDebugging() && wVA == cip) //cip + not running
+        {
+            painter->fillRect(QRect(x, y, w, h), QBrush(mCipBackgroundColor));
+            if(!isbookmark) //no bookmark
+            {
+                if(bpxtype & bp_normal) //normal breakpoint
+                {
+                    QColor & bpColor = mBreakpointBackgroundColor;
+                    if(!bpColor.alpha()) //we don't want transparent text
+                        bpColor = mBreakpointColor;
+                    if(bpColor == mCipBackgroundColor)
+                        bpColor = mCipColor;
+                    painter->setPen(bpColor);
+                }
+                else if(bpxtype & bp_hardware) //hardware breakpoint only
+                {
+                    QColor hwbpColor = mHardwareBreakpointBackgroundColor;
+                    if(!hwbpColor.alpha()) //we don't want transparent text
+                        hwbpColor = mHardwareBreakpointColor;
+                    if(hwbpColor == mCipBackgroundColor)
+                        hwbpColor = mCipColor;
+                    painter->setPen(hwbpColor);
+                }
+                else //no breakpoint
+                {
+                    painter->setPen(mCipColor);
+                }
+            }
+            else //bookmark
+            {
+                QColor bookmarkColor = mBookmarkBackgroundColor;
+                if(!bookmarkColor.alpha()) //we don't want transparent text
+                    bookmarkColor = mBookmarkColor;
+                if(bookmarkColor == mCipBackgroundColor)
+                    bookmarkColor = mCipColor;
+                painter->setPen(bookmarkColor);
+            }
+        }
+        else //non-cip address
+        {
+            if(!isbookmark) //no bookmark
+            {
+                if(*label) //label
+                {
+                    if(bpxtype == bp_none) //label only : fill label background
+                    {
+                        painter->setPen(mLabelColor); //red -> address + label text
+                        painter->fillRect(QRect(x, y, w, h), QBrush(mLabelBackgroundColor)); //fill label background
+                    }
+                    else //label + breakpoint
+                    {
+                        if(bpxtype & bp_normal) //label + normal breakpoint
+                        {
+                            painter->setPen(mBreakpointColor);
+                            painter->fillRect(QRect(x, y, w, h), QBrush(mBreakpointBackgroundColor)); //fill red
+                        }
+                        else if(bpxtype & bp_hardware) //label + hardware breakpoint only
+                        {
+                            painter->setPen(mHardwareBreakpointColor);
+                            painter->fillRect(QRect(x, y, w, h), QBrush(mHardwareBreakpointBackgroundColor)); //fill ?
+                        }
+                        else //other cases -> do as normal
+                        {
+                            painter->setPen(mLabelColor); //red -> address + label text
+                            painter->fillRect(QRect(x, y, w, h), QBrush(mLabelBackgroundColor)); //fill label background
+                        }
+                    }
+                }
+                else //no label
+                {
+                    if(bpxtype == bp_none) //no label, no breakpoint
+                    {
+                        QColor background;
+                        if(wIsSelected)
+                        {
+                            background = mSelectedAddressBackgroundColor;
+                            painter->setPen(mSelectedAddressColor); //black address (DisassemblySelectedAddressColor)
+                        }
+                        else
+                        {
+                            background = mAddressBackgroundColor;
+                            painter->setPen(mAddressColor); //DisassemblyAddressColor
+                        }
+                        if(background.alpha())
+                            painter->fillRect(QRect(x, y, w, h), QBrush(background)); //fill background
+                    }
+                    else //breakpoint only
+                    {
+                        if(bpxtype & bp_normal) //normal breakpoint
+                        {
+                            painter->setPen(mBreakpointColor);
+                            painter->fillRect(QRect(x, y, w, h), QBrush(mBreakpointBackgroundColor)); //fill red
+                        }
+                        else if(bpxtype & bp_hardware) //hardware breakpoint only
+                        {
+                            painter->setPen(mHardwareBreakpointColor);
+                            painter->fillRect(QRect(x, y, w, h), QBrush(mHardwareBreakpointBackgroundColor)); //fill red
+                        }
+                        else //other cases (memory breakpoint in disassembly) -> do as normal
+                        {
+                            QColor background;
+                            if(wIsSelected)
+                            {
+                                background = mSelectedAddressBackgroundColor;
+                                painter->setPen(mSelectedAddressColor); //black address (DisassemblySelectedAddressColor)
+                            }
+                            else
+                            {
+                                background = mAddressBackgroundColor;
+                                painter->setPen(mAddressColor);
+                            }
+                            if(background.alpha())
+                                painter->fillRect(QRect(x, y, w, h), QBrush(background)); //fill background
+                        }
+                    }
+                }
+            }
+            else //bookmark
+            {
+                if(*label) //label + bookmark
+                {
+                    if(bpxtype == bp_none) //label + bookmark
+                    {
+                        painter->setPen(mLabelColor); //red -> address + label text
+                        painter->fillRect(QRect(x, y, w, h), QBrush(mBookmarkBackgroundColor)); //fill label background
+                    }
+                    else //label + breakpoint + bookmark
+                    {
+                        QColor color = mBookmarkBackgroundColor;
+                        if(!color.alpha()) //we don't want transparent text
+                            color = mAddressColor;
+                        painter->setPen(color);
+                        if(bpxtype & bp_normal) //label + bookmark + normal breakpoint
+                        {
+                            painter->fillRect(QRect(x, y, w, h), QBrush(mBreakpointBackgroundColor)); //fill red
+                        }
+                        else if(bpxtype & bp_hardware) //label + bookmark + hardware breakpoint only
+                        {
+                            painter->fillRect(QRect(x, y, w, h), QBrush(mHardwareBreakpointBackgroundColor)); //fill ?
+                        }
+                    }
+                }
+                else //bookmark, no label
+                {
+                    if(bpxtype == bp_none) //bookmark only
+                    {
+                        painter->setPen(mBookmarkColor); //black address
+                        painter->fillRect(QRect(x, y, w, h), QBrush(mBookmarkBackgroundColor)); //fill bookmark color
+                    }
+                    else //bookmark + breakpoint
+                    {
+                        QColor color = mBookmarkBackgroundColor;
+                        if(!color.alpha()) //we don't want transparent text
+                            color = mAddressColor;
+                        painter->setPen(color);
+                        if(bpxtype & bp_normal) //bookmark + normal breakpoint
+                        {
+                            painter->fillRect(QRect(x, y, w, h), QBrush(mBreakpointBackgroundColor)); //fill red
+                        }
+                        else if(bpxtype & bp_hardware) //bookmark + hardware breakpoint only
+                        {
+                            painter->fillRect(QRect(x, y, w, h), QBrush(mHardwareBreakpointBackgroundColor)); //fill red
+                        }
+                        else //other cases (bookmark + memory breakpoint in disassembly) -> do as normal
+                        {
+                            painter->setPen(mBookmarkColor); //black address
+                            painter->fillRect(QRect(x, y, w, h), QBrush(mBookmarkBackgroundColor)); //fill bookmark color
+                        }
+                    }
+                }
+            }
+        }
+        painter->drawText(QRect(x + 4, y, w - 4, h), Qt::AlignVCenter | Qt::AlignLeft, text);
+        text = "";
+    }
+    else if(highlightText.length() && text.contains(highlightText, Qt::CaseInsensitive))
+    {
+        //super smart way of splitting while keeping the delimiters (thanks to cypher for guidance)
+        int index = -2;
+        do
+        {
+            index = text.indexOf(highlightText, index + 2, Qt::CaseInsensitive);
+            if(index != -1)
+            {
+                text = text.insert(index + highlightText.length(), QChar('\1'));
+                text = text.insert(index, QChar('\1'));
+            }
+        }
+        while(index != -1);
+        QStringList split = text.split(QChar('\1'), QString::SkipEmptyParts, Qt::CaseInsensitive);
+
+        //create rich text list
+        RichTextPainter::CustomRichText_t curRichText;
+        curRichText.flags = RichTextPainter::FlagColor;
+        curRichText.textColor = textColor;
+        curRichText.highlightColor = ConfigColor("SearchListViewHighlightColor");
+        RichTextPainter::List richText;
+        foreach(QString str, split)
+        {
+            curRichText.text = str;
+            curRichText.highlight = !str.compare(highlightText, Qt::CaseInsensitive);
+            richText.push_back(curRichText);
+        }
+
+        //paint the rich text
+        RichTextPainter::paintRichText(painter, x + 1, y, w, h, 4, richText, mFontMetrics);
+        text = "";
+    }
+    return text;
+}
+
+void ZehSymbolTable::updateColors()
+{
+    AbstractStdTable::updateColors();
+
+    mCipBackgroundColor = ConfigColor("DisassemblyCipBackgroundColor");
+    mCipColor = ConfigColor("DisassemblyCipColor");
+    mBreakpointBackgroundColor = ConfigColor("DisassemblyBreakpointBackgroundColor");
+    mBreakpointColor = ConfigColor("DisassemblyBreakpointColor");
+    mHardwareBreakpointBackgroundColor = ConfigColor("DisassemblyHardwareBreakpointBackgroundColor");
+    mHardwareBreakpointColor = ConfigColor("DisassemblyHardwareBreakpointColor");
+    mBookmarkBackgroundColor = ConfigColor("DisassemblyBookmarkBackgroundColor");
+    mBookmarkColor = ConfigColor("DisassemblyBookmarkColor");
+    mLabelColor = ConfigColor("DisassemblyLabelColor");
+    mLabelBackgroundColor = ConfigColor("DisassemblyLabelBackgroundColor");
+    mSelectedAddressBackgroundColor = ConfigColor("DisassemblySelectedAddressBackgroundColor");
+    mSelectedAddressColor = ConfigColor("DisassemblySelectedAddressColor");
+    mAddressBackgroundColor = ConfigColor("DisassemblyAddressBackgroundColor");
+    mAddressColor = ConfigColor("DisassemblyAddressColor");
+    mTracedBackgroundColor = ConfigColor("DisassemblyTracedBackgroundColor");
+
+    auto a = selectionColor, b = mTracedBackgroundColor;
+    mTracedSelectedAddressBackgroundColor = QColor((a.red() + b.red()) / 2, (a.green() + b.green()) / 2, (a.blue() + b.blue()) / 2);
 }

--- a/src/gui/Src/Gui/ZehSymbolTable.h
+++ b/src/gui/Src/Gui/ZehSymbolTable.h
@@ -1,21 +1,30 @@
 #pragma once
 
 #include "AbstractStdTable.h"
+#include <QMutex>
 
 class ZehSymbolTable : public AbstractStdTable
 {
     Q_OBJECT
 public:
-    ZehSymbolTable(QWidget* parent);
+    ZehSymbolTable(QWidget* parent = nullptr);
 
     QString getCellContent(int r, int c) override;
     bool isValidIndex(int r, int c) override;
     void sortRows(int column, bool ascending) override;
 
     friend class SymbolView;
+    friend class SearchListViewSymbols;
+
+protected:
+    QString paintContent(QPainter* painter, dsint rowBase, int rowOffset, int col, int x, int y, int w, int h) override;
+    void updateColors() override;
 
 private:
-    std::vector<void*> mData;
+    std::vector<duint> mModules;
+    std::vector<SYMBOLPTR> mData;
+    QMutex mMutex;
+    QString highlightText;
 
     enum
     {
@@ -24,4 +33,22 @@ private:
         ColDecorated,
         ColUndecorated
     };
+
+    QColor mCipBackgroundColor;
+    QColor mCipColor;
+    QColor mBreakpointBackgroundColor;
+    QColor mBreakpointColor;
+    QColor mHardwareBreakpointBackgroundColor;
+    QColor mHardwareBreakpointColor;
+    QColor mBookmarkBackgroundColor;
+    QColor mBookmarkColor;
+    QColor mLabelColor;
+    QColor mLabelBackgroundColor;
+    QColor mSelectedAddressBackgroundColor;
+    QColor mSelectedAddressColor;
+    QColor mAddressBackgroundColor;
+    QColor mAddressColor;
+    QColor mTracedBackgroundColor;
+    QColor mTracedSelectedAddressBackgroundColor;
+    bool bCipBase;
 };

--- a/src/gui/x64dbg.pro
+++ b/src/gui/x64dbg.pro
@@ -102,6 +102,7 @@ SOURCES += \
     Src/Gui/SymbolView.cpp \
     Src/Gui/RegistersView.cpp \
     Src/BasicView/SearchListView.cpp \
+    Src/BasicView/SearchListViewSymbols.cpp \
     Src/BasicView/ReferenceView.cpp \
     Src/Gui/ThreadView.cpp \
     Src/Gui/SettingsDialog.cpp \
@@ -221,6 +222,7 @@ HEADERS += \
     Src/Gui/CPUStack.h \
     Src/Gui/SymbolView.h \
     Src/BasicView/SearchListView.h \
+    Src/BasicView/SearchListViewSymbols.h \
     Src/BasicView/ReferenceView.h \
     Src/Gui/ThreadView.h \
     Src/Gui/SettingsDialog.h \


### PR DESCRIPTION
As you can see the most important fix here is that x32dbg can now run the infamous 64K sections exe from Corkami! This is such a critical feature that maybe it should just be pushed straight to the main repo with priority status. I expect many people have been waiting for this feature for years.

Also improved robustness of debug directory parsing - mostly just validating all fields (RVAs/types/sizes) in any way I could think of, but I probably still missed some things. See if you can spot anything.

I'll let you decide what to do with `ReadBaseRelocationTable()`: at the very least the TitanEngine removals in order to use `RtlImageDirectoryEntryToData` should stay, but other than that I don't really have a strong opinion either way. I only realised after rewriting the function that there wasn't really anything wrong with it to begin with. (unlike import and export parsing which both still need a lot of work before they will be able to survive actual packed/malicious files in the wild).